### PR TITLE
Release 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ bin/
 .idea/
 .serverless/
 .terraform/
-remote.tf
+remote-tfc.tf

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 bin/
 .idea/
 .serverless/
+.terraform/
+remote.tf

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # bitbucket-2fa-monitor
 A serverless function to monitor a Bitbucket workspace to ensure members are using 2FA
+
+## Development setup
+
+### Using Goland
+
+1. Edit Run/Debug Configurations
+1. Run kind: Directory
+1. Directory: /(your path)/bitbucket-2fa-monitor/monitor
+1. Output directory: /(your path)/bitbucket-2fa-monitor/bin
+1. Environment:
+
+  - API_WORKSPACE=(your workspace)
+  - API_USERNAME=(your username)
+  - API_APP_PASSWORD=(your app password)
+  - API_BASE_URL=https://api.bitbucket.org
+  - DEBUG=true

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,10 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/aws/aws-lambda-go v1.22.0 h1:X7BKqIdfoJcbsEIi+Lrt5YjX1HnZexIbNWOQgkYKgfE=
 github.com/aws/aws-lambda-go v1.22.0/go.mod h1:jJmlefzPfGnckuHdXX7/80O3BvUUi12XOkbv4w9SGLU=
-github.com/aws/aws-sdk-go v1.36.25 h1:foHwQg8LGGuR9L8IODs2co5OQqjYhNNrngefIbXbyjg=
-github.com/aws/aws-sdk-go v1.36.25/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.36.31 h1:BMVngapDGAfLBVEVzaSIw3fmJdWx7jOvhLCXgRXbXQI=
 github.com/aws/aws-sdk-go v1.36.31/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -20,7 +17,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
@@ -43,7 +39,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/monitor/bitbucket.go
+++ b/monitor/bitbucket.go
@@ -11,7 +11,7 @@ import (
 
 const countPerPage = 500
 
-var workspaceMembersURLPath = "/2.0/workspaces/{workspace}/members?fields=values.user.display_name,values.user.nickname,values.user.has_2fa_enabled"
+var workspaceMembersURLPath = "/2.0/workspaces/{workspace}/members?fields=size,values.user.display_name,values.user.nickname,values.user.has_2fa_enabled"
 
 type bitbucketMember struct {
 	DisplayName   string `json:"display_name"`

--- a/monitor/bitbucket_test.go
+++ b/monitor/bitbucket_test.go
@@ -5,55 +5,43 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 const bitbucketResponse = `{
-	"values": [
-		{
-			"display_name": "Negative Test",
-			"nickname": "example",
-			"has_2fa_enabled": null
-		},
-		{
-			"display_name": "Positive Test",
-			"nickname": "example",
-			"has_2fa_enabled": true
-		}
-	],
-	"size": 2
+  "values": [
+    {
+      "user": {
+		"nickname": "example",
+		"display_name": "Negative Test",
+		"has_2fa_enabled": null
+      }
+    },
+    {
+      "user": {
+		"nickname": "example",
+		"display_name": "Positive Test",
+		"has_2fa_enabled": true
+      }
+    }
+  ]
 }`
 
 func TestGetNon2svWorkspaceMembers(t *testing.T) {
 	assert := require.New(t)
-	mux := http.NewServeMux()
-	server := httptest.NewServer(mux)
 
-	handler := func(w http.ResponseWriter, req *http.Request) {
-		jsonBytes, err := json.Marshal(bitbucketResponse)
-		if err != nil {
-			t.Errorf("Unable to marshal fixture results, error: %s", err.Error())
-			t.FailNow()
-		}
-
-		w.WriteHeader(200)
-		w.Header().Set("content-type", "application/json")
-
-		s, _ := strconv.Unquote(string(jsonBytes))
-		_, _ = fmt.Fprintf(w, s)
-	}
-
-	mux.HandleFunc(workspaceMembersURLPath, handler)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		_, _ = fmt.Fprint(w, bitbucketResponse)
+	}))
 
 	var members bitbucketMembers
 
 	exBytes := []byte(bitbucketResponse)
 	err := json.Unmarshal(exBytes, &members)
 	assert.NoError(err, "error unmarshalling fixtures")
-	want := members.Values[:1]
+	want := []bitbucketMember{members.Values[:1][0].User}
 
 	var api bitbucketAPI
 	api.BaseURL = server.URL

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -36,10 +36,12 @@ func (app *appContext) init() {
 		Username:    getRequiredEnvironmentVariable(envAPIUsername),
 		AppPassword: getRequiredEnvironmentVariable(envAPIAppPassword),
 	}
-	app.Mailer = mail{
-		CharSet:         getRequiredEnvironmentVariable(envSesCharset),
-		ReturnToAddr:    getRequiredEnvironmentVariable(envSesReturnToAddress),
-		RecipientEmails: getRequiredEnvironmentVariableAsSlice(envSesRecipientEmails, envSep),
+	if !debug {
+		app.Mailer = mail{
+			CharSet:         getRequiredEnvironmentVariable(envSesCharset),
+			ReturnToAddr:    getRequiredEnvironmentVariable(envSesReturnToAddress),
+			RecipientEmails: getRequiredEnvironmentVariableAsSlice(envSesRecipientEmails, envSep),
+		}
 	}
 
 	workspaceMembersURLPath = strings.ReplaceAll(workspaceMembersURLPath, "{workspace}", app.API.Workspace)

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -76,6 +76,9 @@ func handler(app appContext) error {
 
 	members, err := app.API.getNon2svWorkspaceMembers()
 	if err != nil {
+		if !debug {
+			app.Mailer.sendEmail(err.Error())
+		}
 		return err
 	}
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,7 +8,7 @@ provider:
   versionFunctions: false
   memorySize: 512
   region: us-east-1
-  logRetentionInDays: 14
+  logRetentionInDays: 30
   iamRoleStatements:
     - Effect: "Allow"
       Action:

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.1.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:2iNZdsu+8nROjA7hHJs2JwAXAH10a0BAK3RAl2rGnDM=",
+    "zh:0e4143cf20943e0efd96805fe69b5527dd89a023fa67f39c5f4128e5ca736e91",
+    "zh:0f208f3497a2bc977204d195085466804f7c6c9eaa1a3cf864ab2631adf683dd",
+    "zh:2bcfcaad7957504d7572063fc9178a2f4636ad98f24cdd5c74d4ffcc750db5a6",
+    "zh:38100b0cddc1716f2a58d93e55a34272862ffe571439b6d472af26d79a2b5a12",
+    "zh:3bcf9b33dd9d44e9c9562ed45b05511c65ef35496e5a48f58aa31427a76e037f",
+    "zh:6a808deb14ef7b7f8e4f87ceb996bfac88a99d654489eb99d0f2325a0e7b3c09",
+    "zh:81b49e8f8d3e8ec220c206c2f9af83455f1b674481d11ffd279897a2972ec66b",
+    "zh:a37a637c48cd7be608ce248bbed717d154e70b328fccc31ae29ec94f158d64cd",
+    "zh:bdefee374253e800402c5f2ef4637836ba7d6c6889a6c8bb4ffd0602e95b8877",
+    "zh:cdc2df5a3bd5cdeff497572a74c023e102e087dd39610afeef27b1c3d15541a0",
+    "zh:f3fc038d953b35f4ed3572a71d92151ed99d56a9bc3a3eaa6670be6120e30588",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,19 @@
+
+/*
+ * Create IAM user for Serverless framework to use to deploy Bitbucket 2fa monitor
+ */
+module "bitbucket-2fa-monitor-serverless-user" {
+  source  = "silinternational/serverless-user/aws"
+  version = "0.1.0"
+
+  app_name   = "bitbucket-2fa-mon"
+  aws_region = var.aws_region
+}
+
+output "bitbucket-2fa-monitor-access-key-id" {
+  value = module.bitbucket-2fa-monitor-serverless-user.aws_access_key_id
+}
+output "bitbucket-2fa-monitor-secret-access-key" {
+  value     = module.bitbucket-2fa-monitor-serverless-user.aws_secret_access_key
+  sensitive = true
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  region     = var.aws_region
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,9 @@
+variable "aws_region" {
+  default = "us-east-1"
+}
+
+variable "aws_access_key" {
+}
+
+variable "aws_secret_key" {
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,10 @@
+
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
### Fixed
- Updated to new Bitbucket API.
- If API returns an error status, log the body of the API response.
### Added
- Send an email in case of an error.
- Added a bit of documentation for local development.
- Terraform config to manage AWS IAM user for serverless deployment. This is being move here from a shared repo.
### Changed
- For local experimentation, don't require SES environment variables.
- Increased log retention to 30 days (was 14)